### PR TITLE
Update for Zotac's domain change back to zotacstore.com/us

### DIFF
--- a/tampermonkey/zotac.autocartviabutton.user.js
+++ b/tampermonkey/zotac.autocartviabutton.user.js
@@ -4,7 +4,7 @@
 // @version      2021061001
 // @description  try to take over the world!
 // @author       You
-// @match        https://us.zotacstore.com/*
+// @match        https://www.zotacstore.com/*
 // @icon         https://www.google.com/s2/favicons?domain=zotacstore.com
 // @grant        none
 // ==/UserScript==
@@ -28,7 +28,7 @@ if(pagetitle.includes("ZOTAC GAMING GeForce RTX 30")) {
           if (document.querySelector('[title="Add To Cart"]')) {
             console.log("Trying to Cart");
             document.querySelector('[title="Add To Cart"]').click();
-            window.location = "https://us.zotacstore.com/us/checkout/#shipping";
+            window.location = "https://www.zotacstore.com/us/checkout/#shipping";
           }
         } else {
       console.log("Out of Stock");

--- a/tampermonkey/zotac.captchadetector.user.js
+++ b/tampermonkey/zotac.captchadetector.user.js
@@ -4,7 +4,7 @@
 // @version      2021060403
 // @description  try to take over the world!
 // @author       You
-// @match        https://us.zotacstore.com/us/*
+// @match        https://www.zotacstore.com/us/*
 // @icon         https://www.google.com/s2/favicons?domain=zotacstore.com
 // @grant        none
 // ==/UserScript==

--- a/tampermonkey/zotac.cartfromwishlist.user.js
+++ b/tampermonkey/zotac.cartfromwishlist.user.js
@@ -4,7 +4,7 @@
 // @version      2021060305
 // @description  try to take over the world!
 // @author       You
-// @match        https://us.zotacstore.com/us/*
+// @match        https://www.zotacstore.com/us/*
 // @icon         https://www.google.com/s2/favicons?domain=zotacstore.com
 // @grant        none
 // ==/UserScript==

--- a/tampermonkey/zotac.checkout-launch-paypal-once.user.js
+++ b/tampermonkey/zotac.checkout-launch-paypal-once.user.js
@@ -4,7 +4,7 @@
 // @version      2021061101
 // @description  try to take over the world!
 // @author       You
-// @match        https://us.zotacstore.com/*
+// @match        https://www.zotacstore.com/*
 // @icon         https://www.google.com/s2/favicons?domain=zotacstore.com
 // @grant        none
 // ==/UserScript==
@@ -29,7 +29,7 @@ setInterval(function() {
 	if (localStorage.getItem("paypal") == "0") {
 	    localStorage.setItem("paypal","1");
 	    console.log("Launching paypal express start");
-	    window.open("https://us.zotacstore.com/us/paypal/express/start");
+	    window.open("https://www.zotacstore.com/us/paypal/express/start");
 	} else {
 	    console.log("paypal set to 1");
             console.log("Did you do localStorage.setItem step?");

--- a/tampermonkey/zotac.checkoutmonitor.user.js
+++ b/tampermonkey/zotac.checkoutmonitor.user.js
@@ -4,7 +4,7 @@
 // @version      2021061403
 // @description  try to take over the world!
 // @author       You
-// @match        https://us.zotacstore.com/us/checkout/*
+// @match        https://www.zotacstore.com/us/checkout/*
 // @icon         https://www.google.com/s2/favicons?domain=zotacstore.com
 // @downloadURL  https://github.com/krowve/zotacscripts/raw/main/tampermonkey/zotac.checkoutoutmonitor.user.js
 // @updateURL    https://github.com/krowve/zotacscripts/raw/main/tampermonkey/zotac.checkoutoutmonitor.user.js
@@ -40,9 +40,9 @@ setInterval(function() {
             checkout = 0;
         }
         if (checkout) {
-            window.location = "https://us.zotacstore.com/us/checkout/#shipping";
+            window.location = "https://www.zotacstore.com/us/checkout/#shipping";
         } else {
-        setTimeout(function(){ window.location = "https://us.zotacstore.com/us/checkout/#shipping" }, 15000);
+        setTimeout(function(){ window.location = "https://www.zotacstore.com/us/checkout/#shipping" }, 15000);
         }
 
     }
@@ -56,7 +56,7 @@ setInterval(function() {
     if (localStorage.getItem("paypal") == "0") {
 	    localStorage.setItem("paypal","1");
 	    console.log("Launching paypal express start");
-	    window.open("https://us.zotacstore.com/us/paypal/express/start");
+	    window.open("https://www.zotacstore.com/us/paypal/express/start");
 	} else {
 	    console.log("paypal set to 1");
             console.log("Did you do localStorage.setItem step?");

--- a/tampermonkey/zotac.form_key.user.js
+++ b/tampermonkey/zotac.form_key.user.js
@@ -4,7 +4,7 @@
 // @version      2021061101
 // @description  try to take over the world!
 // @author       You
-// @match        https://us.zotacstore.com/*
+// @match        https://www.zotacstore.com/*
 // @icon         https://www.google.com/s2/favicons?domain=zotacstore.com
 // ==/UserScript==
 

--- a/tampermonkey/zotac.launchfromcart.user.js
+++ b/tampermonkey/zotac.launchfromcart.user.js
@@ -4,7 +4,7 @@
 // @version      2021061101
 // @description  try to take over the world!
 // @author       You
-// @match        https://us.zotacstore.com/us/checkout/*
+// @match        https://www.zotacstore.com/us/checkout/*
 // @icon         https://www.google.com/s2/favicons?domain=zotacstore.com
 // @grant        none
 // ==/UserScript==
@@ -47,7 +47,7 @@ if (pagetitle.includes("Shopping Cart")) {
               audio.play();
               //window.open(AUDIOURL);
               console.log("Launching Checkout Link.  ");
-              window.open("https://us.zotacstore.com/us/checkout/#shipping");
+              window.open("https://www.zotacstore.com/us/checkout/#shipping");
               clearInterval(idVar);
             } else {
 		console.log("In stock but not carting");


### PR DESCRIPTION
These scripts were originally designed to be used on us.zotacstore.com, but Zotac has recently migrated the store back to zotacstore.com/us. Despite that us.zotacstore.com now redirects you to zotacstore.com/us, the scripts stopped working for some users. Most Notably Brave Browser users.
Special thanks to @44cortseverns44 (twitch) for the help & direction with Brave! I was glad to have it, and now because of it I was able to use Github for the first time to make my first ever pull request! I feel so proud! <3
Now let's get these GPU's everybody!!